### PR TITLE
Optimize rendering speed of steering and car video

### DIFF
--- a/Autopilot/DriveApp.py
+++ b/Autopilot/DriveApp.py
@@ -1,6 +1,7 @@
 import numpy as np
 import cv2
 from keras.models import load_model
+import time
 
 model = load_model('models/Autopilot.h5')
 
@@ -14,7 +15,7 @@ def keras_predict(model, image):
 def keras_process_image(img):
     image_x = 40
     image_y = 40
-    img = cv2.resize(img, (image_x, image_y))
+    img = cv2.resize(img, (image_x, image_y), interpolation=cv2.INTER_LINEAR)
     img = np.array(img, dtype=np.float32)
     img = np.reshape(img, (-1, image_x, image_y, 1))
     return img
@@ -25,18 +26,25 @@ rows, cols = steer.shape
 smoothed_angle = 0
 
 cap = cv2.VideoCapture('resources/run.mp4')
+cap.set(cv2.CAP_PROP_FPS, 60)
+cv2.namedWindow('frame', cv2.WINDOW_NORMAL)
+cv2.namedWindow('steering wheel', cv2.WINDOW_NORMAL)
 while (cap.isOpened()):
+    start_time = time.time()
     ret, frame = cap.read()
-    gray = cv2.resize((cv2.cvtColor(frame, cv2.COLOR_RGB2HSV))[:, :, 1], (40, 40))
+    gray = cv2.resize((cv2.cvtColor(frame, cv2.COLOR_RGB2HSV))[:, :, 1], (40, 40), interpolation=cv2.INTER_LINEAR)
     steering_angle = keras_predict(model, gray)
     print(steering_angle)
-    cv2.imshow('frame', cv2.resize(frame, (500, 300), interpolation=cv2.INTER_AREA))
+    cv2.imshow('frame', cv2.resize(frame, (500, 300), interpolation=cv2.INTER_LINEAR))
     smoothed_angle += 0.2 * pow(abs((steering_angle - smoothed_angle)), 2.0 / 3.0) * (
         steering_angle - smoothed_angle) / abs(
         steering_angle - smoothed_angle)
     M = cv2.getRotationMatrix2D((cols / 2, rows / 2), -smoothed_angle, 1)
     dst = cv2.warpAffine(steer, M, (cols, rows))
     cv2.imshow("steering wheel", dst)
+    end_time = time.time()
+    fps = 1 / (end_time - start_time)
+    print("FPS: ", fps)
 
     if cv2.waitKey(1) & 0xFF == ord('q'):
         break

--- a/Autopilot_V2/AutopilotApp_V2.py
+++ b/Autopilot_V2/AutopilotApp_V2.py
@@ -1,6 +1,7 @@
 import numpy as np
 import cv2
 from keras.models import load_model
+import time
 
 model = load_model('models/Autopilot.h5')
 
@@ -14,7 +15,7 @@ def keras_predict(model, image):
 def keras_process_image(img):
     image_x = 100
     image_y = 100
-    img = cv2.resize(img, (image_x, image_y))
+    img = cv2.resize(img, (image_x, image_y), interpolation=cv2.INTER_LINEAR)
     img = np.array(img, dtype=np.float32)
     img = np.reshape(img, (-1, image_x, image_y, 1))
     return img
@@ -25,18 +26,25 @@ rows, cols = steer.shape
 smoothed_angle = 0
 
 cap = cv2.VideoCapture('run.mp4')
+cap.set(cv2.CAP_PROP_FPS, 60)
+cv2.namedWindow('frame', cv2.WINDOW_NORMAL)
+cv2.namedWindow('steering wheel', cv2.WINDOW_NORMAL)
 while (cap.isOpened()):
+    start_time = time.time()
     ret, frame = cap.read()
-    gray = cv2.resize((cv2.cvtColor(frame, cv2.COLOR_RGB2HSV))[:, :, 1], (100, 100))
+    gray = cv2.resize((cv2.cvtColor(frame, cv2.COLOR_RGB2HSV))[:, :, 1], (100, 100), interpolation=cv2.INTER_LINEAR)
     steering_angle = keras_predict(model, gray)
     print(steering_angle)
-    cv2.imshow('frame', cv2.resize(frame, (600, 400), interpolation=cv2.INTER_AREA))
+    cv2.imshow('frame', cv2.resize(frame, (600, 400), interpolation=cv2.INTER_LINEAR))
     smoothed_angle += 0.2 * pow(abs((steering_angle - smoothed_angle)), 2.0 / 3.0) * (
         steering_angle - smoothed_angle) / abs(
         steering_angle - smoothed_angle)
     M = cv2.getRotationMatrix2D((cols / 2, rows / 2), -smoothed_angle, 1)
     dst = cv2.warpAffine(steer, M, (cols, rows))
     cv2.imshow("steering wheel", dst)
+    end_time = time.time()
+    fps = 1 / (end_time - start_time)
+    print("FPS: ", fps)
 
     if cv2.waitKey(1) & 0xFF == ord('q'):
         break


### PR DESCRIPTION
Fixes #15

Optimize the rendering speed of both the steering and car video in `Autopilot_V2/AutopilotApp_V2.py` and `Autopilot/DriveApp.py`.

* **Autopilot_V2/AutopilotApp_V2.py**
  - Import `time` module.
  - Optimize `cv2.resize` function by using `cv2.INTER_LINEAR` interpolation method.
  - Set `cv2.CAP_PROP_FPS` property to 60 for `cv2.VideoCapture`.
  - Add `cv2.WINDOW_NORMAL` flag to `cv2.namedWindow` for 'frame' and 'steering wheel'.
  - Add a timer to measure the time taken for each frame processing and display the FPS.

* **Autopilot/DriveApp.py**
  - Import `time` module.
  - Optimize `cv2.resize` function by using `cv2.INTER_LINEAR` interpolation method.
  - Set `cv2.CAP_PROP_FPS` property to 60 for `cv2.VideoCapture`.
  - Add `cv2.WINDOW_NORMAL` flag to `cv2.namedWindow` for 'frame' and 'steering wheel'.
  - Add a timer to measure the time taken for each frame processing and display the FPS.

